### PR TITLE
[DM-34335] Reorganize documentation, update rules, add bot users

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,36 +1,12 @@
 name: CI
 
-"on": [push, pull_request]
+'on': [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # full history for metadata
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Python install
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install "ltd-conveyor<2.0.0"
-
-      - name: Build
-        run: |
-          make html
-
-      - name: Upload
-        if: ${{ github.event_name == 'push' }}
-        env:
-          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
-          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
-        run: |
-          ltd upload --gh --dir _build/html --product dmtn-225
+  call-workflow:
+    uses: lsst-sqre/rubin-sphinx-technote-workflows/.github/workflows/ci.yaml@v1
+    with:
+      handle: dmtn-225
+    secrets:
+      ltd_username: ${{ secrets.LTD_USERNAME }}
+      ltd_password: ${{ secrets.LTD_PASSWORD }}

--- a/conf.py
+++ b/conf.py
@@ -1,22 +1,9 @@
-#!/usr/bin/env python
-#
-# Sphinx configuration file
-# see metadata.yaml in this repo to update document-specific metadata
+"""Sphinx configuration.
 
-import os
-from documenteer.sphinxconfig.technoteconf import configure_technote
+To learn more about the Sphinx configuration for technotes, and how to
+customize it, see:
 
-# Ingest settings from metadata.yaml and use documenteer's configure_technote()
-# to build a Sphinx configuration that is injected into this script's global
-# namespace.
-metadata_path = os.path.join(os.path.dirname(__file__), 'metadata.yaml')
-with open(metadata_path, 'r') as f:
-    confs = configure_technote(f)
-g = globals()
-g.update(confs)
+https://documenteer.lsst.io/technotes/configuration.html
+"""
 
-# Add intersphinx inventories as needed
-# http://www.sphinx-doc.org/en/stable/ext/intersphinx.html
-# Example:
-#
-#     intersphinx_mapping['python'] = ('https://docs.python.org/3', None)
+from documenteer.conf.technote import *  # noqa: F401, F403

--- a/index.rst
+++ b/index.rst
@@ -8,124 +8,115 @@ Abstract
 The Rubin Science Platform will store various metadata about each user, either created by the Science Platform (such as some identifiers) or collected from the relevant identity provider.
 This document describes the metadata associated with users and its sources and constraints, such as numeric ranges for UIDs and GIDs and valid patterns for usernames and group names.
 
-While this document is primarily about general users of the Science Platform deployment at the :abbr:`IDF (Interim Data Facility)` and :abbr:`CDF (Cloud Data Facility)`, it also records the differences for other Science Platform deployments (such as ones internal to the project) where known.
+This document is divided into three sections, one for the :abbr:`IDF (Interim Data Facility)` and :abbr:`CDF (Cloud Data Facility)`, one for Telescope and Site deployments, and one for the :abbr:`USDF (United States Data Facility)`.
+
+IDF and CDF
+===========
 
 User metadata
-=============
+-------------
 
-This is the user metadata that we are storing so far.
 We expect to add additional metadata, such as whether a user has accepted the Acceptable Use Policy, before the production release.
 This tech note will be updated when we add additional metadata.
 
 Username
---------
+^^^^^^^^
 
 **Source**: User chooses their (unique) username during enrollment.
-For internal deployments using GitHub as the authentication source, the username is the same as their GitHub username converted to all lowercase.
-For internal deployments using a local authentication provider, their username is whatever username is returned by the local authentication provider (usually via the ``sub`` claim in the OpenID Connect JWT).
 
-**Storage**: The username is used as a unique key for the user in all identity management systems except for COmanage.
-In COmanage, it is stored as an identifier associated with the user's record.
+**Storage**: In COmanage, it is stored as an identifier associated with the user's record.
+CILogon provides a unique opaque identifier during authentication.
+The user's LDAP record is then retrieved via a search for that identifier, and the username is taken from the ``uid`` field of that LDAP record.
+It is then also stored in Redis as data associated with each authentication token.
 
 **Constraints**: Must consist solely of lowercase ASCII letters, numbers, and dash (``-``), must not start or end with a dash, and must not contain two consecutive dashes. [#]_
 Must not consist entirely of numbers.
+Usernames for bot users (users created for automated processes or services, not for human users) must begin with ``bot-``.
 
 .. [#] Regular expression: ``^[a-z0-9](?:[a-z0-9]|-[a-z0-9])*$``
 
 Numeric UID
------------
+^^^^^^^^^^^
 
 **Source**: Assigned by the Science Platform on first use of an account.
-All IDF and CDF Science Platform deployments share the same UID assignment pool and map the same CILogon identity to the same UID.
-Internal deployments using GitHub as the authentication source use the UID from GitHub.
-Internal deployments using a local authentication provider may use either a configurable JWT claim from OpenID Connect or a configurable LDAP attribute from a local LDAP server.
+All production and integration IDF and CDF Science Platform deployments share the same UID assignment pool and map the same CILogon identity to the same UID.
+Development deployments may use a different UID assignment pool and therefore not use the same UIDs.
 
-**Storage**: For public deployments, stored within the Science Platform user database, which is shared between all IDF and CDF deployments.
-For all deployments, the UID number is also stored in the token and retrieved via the token API.
+**Storage**: One document per user is stored in `Google Firestore`_
+This currently contains only the UID, but in the future may contain other metadata maintained by the Science Platform rather than COmanage and CILogon.
+As an optimization, since the UID never changes, it is also stored as data associated with each authentication token in Redis.
+
+.. _Google Firestore: https://cloud.google.com/firestore
 
 **Constraints**: See :ref:`UID and GID assignment <uid-gid-assignment>`.
 UIDs are unique and are intended to never be reused.
 Once assigned, the UID for a given account never changes, even if the username is changed.
 
 Full name
----------
+^^^^^^^^^
 
 **Source**: Taken from the user's federated identity provider during enrollment.
 The user may choose to enter a new name.
 Insofar as possible, the Rubin Science Platform will only record the user's entire name of choice as a single text field, not divided into components such as given name and family name.
 COmanage currently does not properly support this, and may represent the name in components, but the Science Platform will attempt to use the combined form only.
-For internal deployments using GitHub as the authentication source, the name is taken from the GitHub account metadata.
-For internal deployments using a local authentication provider, the name is taken from the ``name`` claim in the issued OpenID Connect JWT.
 
 **Storage**: The names from each associated federated identity are stored in COmanage, along with any name the user chooses to enter.
 Whatever name they choose as primary is stored as the ``displayName`` attribute in the user's LDAP record as maintained by COmanage, and is retrieved from there by the Science Platform using the token API.
-For deployments that do not use COmanage, the name is determined during authentication, stored with the user's authentication token, and retrieved as needed via the token API.
 
 **Constraints**: Any valid UTF-8 string of reasonable length without control characters.
 No assumptions are made about the structure of the name.
 
 Email address
--------------
+^^^^^^^^^^^^^
 
 **Source**: Taken from the user's federated identity provider during enrollment.
 The user may choose to enter a new email address.
-For internal deployments using GitHub as the authentication source, the email address is taken from the GitHub account metadata.
-For internal deployments using a local authentication provider, the name is taken from the ``email`` claim in the issued OpenID Connect JWT.
 
 **Storage**: The email addresses from each associated federated identity are stored in COmanage, along with any email the user chooses to enter.
 Whatever email address they choose as primary is stored as the ``mail`` attribute in the user's LDAP record as maintained by COmanage, and is retrieved from there by the Science Platform using the token API.
-For deployments that do not use COmanage, the email address is determined during authentication, stored with the user's authentication token, and retrieved as needed via the token API.
 
 **Constraints**: Must be a syntactically-valid `RFC 5322 addr-spec <https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1>`__.
 COmanage will confirm the validity of the email address during enrollment by sending the user an email and having them follow a link in the email.
 
 Group membership
-----------------
+^^^^^^^^^^^^^^^^
 
 **Source**: COmanage records the user's group membership (except in their default group).
 Users are added to groups by group owners, and may be added to groups based on automated rules triggering off of their affiliation data.
-For internal deployments using GitHub as the authentication source, the user's group membership is derived from their organization and team memberships.
-For internal deployments using a local authentication mechanism, the user's group membership may be taken from an ``isMemberOf`` claim in the OpenID Connect JWT, or by querying a local LDAP server.
+Users are also automatically a member of a default group with the same name as the username.
 
 **Storage**: COmanage stores the user's group membership information and provides it in the LDAP server it maintains, as ``member`` attributes in a groups tree.
-The group membership for a given user can be retrieved via the token API.
-For internal deployments, either a local LDAP server is used, in which case group membership is handled much the same way as it is with COmanage, or it can be determined during authentication.
-In the latter case, it is stored in the user's tokens and can be retrieved via the token API.
+Group membership information is retrieved from LDAP each time it is needed.
+However, be aware that the scopes of an authentication token are calculated from the group membership at the time of initial user authentication and are not affected by subsequent changes to the user's group membership until that token expires.
 
 **Constraints**: There is no inherent limit in the number of groups a user may be a member of, but be aware that NFS only allows a user to be a member of 16 groups, one of which is the user's default group.
 Group memberships above 16 may be ignored by the NFS server.
 
 Group metadata
-==============
+--------------
 
 Group name
-----------
+^^^^^^^^^^
 
 (The below rules only apply to additional groups.
-The user's default group has the same name as the username.)
+The user's default group has the same name as the username and the same GID as the user's UID.)
 
-**Source**: Groups managed in COmanage are named when created manually.
-Groups that come from a local authentication provider use whatever names the local authentication provider provides.
-For internal deployments that use GitHub is used as the authentication provider, each team that the user is a member of corresponds to one group.
-The name of the group is the lowercase form of the organization, a dash (``-``), and the "slug" of the team as retrieved from the GitHub API.
-If the resulting group name is longer than 32 characters, it is truncated at 25 characters and the first six characters of a hash of the full name will be appended.
+**Source**: Groups are named in COmanage when they are created.
 
 **Storage**: Group names are stored where user group membership is stored.
 
-**Constraints**: For IDF and CDF deployments, all group names must begin with ``g_``.
-Group names must consist of lowercase ASCII letters and numbers, period (``.``), dash (``-``), and underscore (``_``), must begin with a letter, and must be at most 32 characters long.
-For internal deployments, uppercase letters are also allowed.
+**Constraints**: All group names must begin with ``g_``.
+Group names must consist of lowercase ASCII letters and numbers, period (``.``), dash (``-``), and underscore (``_``), and must be at most 32 characters long.
 
 Numeric GID
------------
+^^^^^^^^^^^
 
 **Source**: Assigned by the Science Platform on first use of a group.
-All IDF and CDF Science Platform deployments share the same GID assignment pool and map the same CILogon group to the same GID.
-Internal deployments using GitHub as the authentication source use the team ID from GitHub.
-Internal deployments using a local authentication provider may use either the ``isMemberOf`` JWT claim from OpenID Connect or the ``gidNumber`` attribute from a local LDAP server.
+All production and integration IDF and CDF Science Platform deployments share the same GID assignment pool and map the same COmanage group to the same GID.
+Development deployments may use a different UID assignment pool and therefore not use the same UIDs.
 
-**Storage**: For public deployments, stored within the Science Platform user database, which is shared between all IDF and CDF deployments.
-For all deployments, the GID number is also stored in the token and retrieved via the token API.
+**Storage**: One document per group is stored in `Google Firestore`_
+This currently contains only the GID, but in the future may contain other metadata maintained by the Science Platform rather than COmanage and CILogon.
 
 **Constraints**: See :ref:`UID and GID assignment <uid-gid-assignment>`.
 GIDs are unique and are intended to never be reused.
@@ -134,9 +125,7 @@ Once assigned, the GID for a given group never changes, even if the group name i
 .. _uid-gid-assignment:
 
 UID and GID assignment
-======================
-
-The following section applies only to Science Platform deployments that use COmanage.
+----------------------
 
 The Science Platform uses a POSIX file system for some storage.
 Access control in that file system is done via numeric UIDs and GIDs.
@@ -148,7 +137,7 @@ That group must also have a unique GID.
 
 For convenience, the GID of the user's default group will always match the user's UID.
 
-The Science Platform requires support for 31-bit or 32-bit UIDs and GIDs and makes no attempt to support platforms with 16-bit UIDs or GIDs.
+The Science Platform requires support for at least 31-bit UIDs and GIDs and makes no attempt to support platforms with 16-bit UIDs or GIDs.
 We can therefore take advantage of the increased UID and GID space up to 2,147,483,648.
 
 UID and GID space is divided into the following ranges:
@@ -160,20 +149,195 @@ UID and GID space is divided into the following ranges:
     Reserved for users created by packages installed in containers, and for the use of some containers that use default UIDs in the high 900s.
 
 1000-999999
-    Reserved for future use.
+    Reserved for users created inside the container image.
+    Most containers use UID 1000 as a default user.
     Note that 65534 is reserved by the operating system.
 
-1000000-1999999
+100000-199999
+    UIDs for bot users and the corresponding GID for the bot user's default group.
+
+200000-299999
     GIDs for groups other than the user's default group.
 
-2000000-2147483646
+300000-999999
     User UIDs and the corresponding GID for the user's default group.
 
+1000000-2147483647
+    Reserved for future use.
+
 UIDs and GIDs are assigned on first use of a given user or group in any Science Platform deployment that shares the same UID and GID assignment database.
-All IDF and CDF deployments will use the same UID and GID assignments so that UIDs and GIDs are portable between deployments.
-We expect to sometimes want to mount the same POSIX file system on multiple deployments.
+We expect to sometimes want to mount the same POSIX file system on multiple deployments, so the same UID and GID assignment store will be shared by all production and integration deployments (but possibly not by development deployments).
 
 Once a given UID or GID has been used, it will never be reused for a different user or group.
 
 COmanage does support assigning UIDs and GIDs, but the configuration complexity required is higher, and our assignment needs are a somewhat awkward fit for COmanage's capabilities.
 We therefore will do UID and GID assignment independently of COmanage.
+
+Telescope and Site
+==================
+
+Currently, Telescope and Site deployments use GitHub for authentication.
+It's possible that the summit deployment will switch to a local identity provider at some point in the future to allow for access while the summit is disconnected from the Internet.
+If this happens, it will likely switch to a model like the :ref:`USDF <usdf>` as described below.
+
+User metadata
+-------------
+
+Username
+^^^^^^^^
+
+**Source**: The user's GitHub username converted to all lowercase.
+
+**Storage**: The username is used as a unique key for the user in all identity management systems.
+
+**Constraints**: Must consist solely of lowercase ASCII letters, numbers, and dash (``-``), must not start or end with a dash, and must not contain two consecutive dashes. [#]_
+Must not consist entirely of numbers.
+
+.. [#] Regular expression: ``^[a-z0-9](?:[a-z0-9]|-[a-z0-9])*$``
+
+Numeric UID
+^^^^^^^^^^^
+
+**Source**: UID assigned by GitHub.
+For bot users that do not exist in GitHub, we make up a UID when an authentication token for the bot user is created and hope it doesn't conflict with a meaningful GitHub user.
+
+**Storage**: Stored as data associated with each token in Redis.
+
+**Constraints**: Whatever constraints are used by GitHub to assign UIDs.
+
+Full name
+^^^^^^^^^
+
+**Source**: Taken from the GitHub account metadata.
+
+**Storage**: Stored as data associated with each token in Redis.
+
+**Constraints**: Any valid UTF-8 string of reasonable length without control characters.
+No assumptions are made about the structure of the name.
+
+Email address
+^^^^^^^^^^^^^
+
+**Source**: Taken from the GitHub account metadata.
+
+**Storage**: Stored as data associated with each token in Redis.
+
+**Constraints**: Whatever constraints are used by GitHub when adding email addresses to an account.
+
+Group membership
+^^^^^^^^^^^^^^^^
+
+**Source**: Derived from GitHub organization and team memberships.
+
+**Storage**: Determined during authentication with GitHub API calls and stored as data associated with each token in Redis.
+
+**Constraints**: There is no inherent limit in the number of groups a user may be a member of, but be aware that NFS only allows a user to be a member of 16 groups, one of which is the user's default group.
+Group memberships above 16 may be ignored by the NFS server.
+
+Group metadata
+--------------
+
+Group name
+^^^^^^^^^^
+
+(The below rules only apply to additional groups.
+The user's default group has the same name as the username.)
+
+**Source**: Each team that the user is a member of corresponds to one group.
+The name of the group is the lowercase form of the organization, a dash (``-``), and the "slug" of the team as retrieved from the GitHub API.
+If the resulting group name is longer than 32 characters, it is truncated at 25 characters and the first six characters of a hash of the full name will be appended.
+
+**Storage**: Group names are stored where user group membership is stored.
+
+**Constraints**: Group names must consist of lowercase ASCII letters and numbers, period (``.``), dash (``-``), and underscore (``_``), must begin with a letter, and must be at most 32 characters long.
+
+Numeric GID
+^^^^^^^^^^^
+
+**Source**: The team ID from GitHub.
+
+**Storage**: Stored as data associated with each token in Redis.
+
+**Constraints**: Whatever constraints GitHub uses to assign team IDs.
+
+USDF
+====
+
+This section is still preliminary, since the SLAC USDF is not yet complete.
+Some of the details may change before the facility is operational.
+
+User metadata
+-------------
+
+Username
+^^^^^^^^
+
+**Source**: The value of the ``sub`` claim in the ID token returned by the OpenID Connect authentication protocol.
+
+**Storage**: Stored as data associated with each token in Redis.
+
+**Constraints**: Must consist solely of lowercase ASCII letters, numbers, and dash (``-``), must not start or end with a dash, and must not contain two consecutive dashes. [#]_
+Must not consist entirely of numbers.
+
+.. [#] Regular expression: ``^[a-z0-9](?:[a-z0-9]|-[a-z0-9])*$``
+
+Numeric UID
+^^^^^^^^^^^
+
+**Source**: The ``uidNumber`` attribute of the user's record in LDAP.
+
+**Storage**: Stored as data associated with each token in Redis.
+
+**Constraints**: Whatever constraints are used by the local identity management system that populates LDAP.
+
+Full name
+^^^^^^^^^
+
+**Source**: The ``displayName`` attribute of the user's record in LDAP.
+
+**Storage**: Retrieved from LDAP when needed and not stored locally in the Science Platform.
+
+**Constraints**: Whatever constraints are used by the local identity management system that populates LDAP.
+No assumptions are made about the structure of the name.
+
+Email address
+^^^^^^^^^^^^^
+
+**Source**: The ``mail`` attribute of the user's record in LDAP.
+
+**Storage**: Retrieved from LDAP when needed and not stored locally in the Science Platform.
+
+**Constraints**: Whatever constraints are used by the local identity management system that populates LDAP.
+
+Group membership
+^^^^^^^^^^^^^^^^
+
+**Source**: All groups in LDAP for which the user is listed as a member.
+Unlike the other deployments, the USDF deployment does not put the user in a default group with the same name as their username.
+
+**Storage**: Retrieved from LDAP when needed and not stored locally in the Science Platform.
+However, be aware that the scopes of an authentication token are calculated from the group membership at the time of initial user authentication and are not affected by subsequent changes to the user's group membership until that token expires.
+
+**Constraints**: There is no inherent limit in the number of groups a user may be a member of, but be aware that NFS only allows a user to be a member of 16 groups, one of which is the user's default group.
+Group memberships above 16 may be ignored by the NFS server.
+
+Group metadata
+--------------
+
+Group name
+^^^^^^^^^^
+
+**Source**: The ``cn`` attribute of the LDAP record for the group.
+
+**Storage**: Retrieved from LDAP when needed and not stored locally in the Science Platform.
+
+**Constraints**: Group names must consist of ASCII letters (upper- or lowercase) and numbers, period (``.``), dash (``-``), and underscore (``_``), must begin with a letter, and must be at most 32 characters long.
+
+Numeric GID
+^^^^^^^^^^^
+
+**Source**: The ``gidNumber`` attribute of the LDAP record for the group.
+
+**Storage**: Retrieved from LDAP when needed and not stored locally in the Science Platform.
+
+**Constraints**: Whatever constraints are used by the local identity management system that populates LDAP.


### PR DESCRIPTION
Rather than trying to describe each deployment in the same structure, document each class of deployments separately in their own section with repeated structure.  Clean up a bunch of the descriptions and make them more accurate.

Add a new UID range for bot users and adjust the GID and regular user UIDs accordingly.  Reserve UIDs below 100000 for container users, and UIDs above 999999 for future use.

Drop any attempt to describe how NCSA works, since NCSA is going away and we don't expect future enviroments to use the same heavy OpenID Connect ID token approach.

Update to the latest GitHub Actions configuration and Sphinx configuration.