### PR TITLE
[DM-35475] Enable fatal warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -n
+SPHINXOPTS    = -W --keep-going -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/index.rst
+++ b/index.rst
@@ -265,6 +265,8 @@ Numeric GID
 
 **Constraints**: Whatever constraints GitHub uses to assign team IDs.
 
+.. _usdf:
+
 USDF
 ====
 


### PR DESCRIPTION
Tell Sphinx to exit with an error if there are any warnings.  Fix
one warning that uncovered.